### PR TITLE
Remove invalid use statements

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1,9 +1,6 @@
 <?php
 namespace SendGrid;
 
-use \Email;
-use \Exception;
-use \Response;
 use GuzzleHttp\Exception\ClientException;
 
 /**


### PR DESCRIPTION
These use statements are importing the *global* `Email`, `Exception`, and `Response` classes. Since those classes do not exist, the local namespace'd classes are used instead.

This error becomes apparent when trying to use the `Client` class elsewhere.