### PR TITLE
Fix test path references

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,7 +19,7 @@ class SendGridTest_Client extends \PHPUnit_Framework_TestCase {
    */
   public function testVersion() {
     $this->assertEquals(s\Client::VERSION, '1.0.8');
-    $this->assertEquals(json_decode(file_get_contents('composer.json'))->version, \SendGrid\Client::VERSION);
+    $this->assertEquals(json_decode(file_get_contents('../composer.json'))->version, s\Client::VERSION);
   }
 
   /**

--- a/tests/WebTest.php
+++ b/tests/WebTest.php
@@ -42,7 +42,7 @@ class SendGridTest_Web extends \PHPUnit_Framework_TestCase {
       ->setSubject('foobar subject')
       ->setText('foobar text')
       ->addTo('p1@mailinator.com')
-      ->addAttachment('./tests/gif.gif');
+      ->addAttachment('gif.gif');
     try {
       $response = $sendgrid->send($email);
     }
@@ -65,7 +65,7 @@ class SendGridTest_Web extends \PHPUnit_Framework_TestCase {
       ->setSubject('foobar subject')
       ->setText('foobar text')
       ->addTo('p1@mailinator.com')
-      ->addAttachment('./tests/text');
+      ->addAttachment('text');
     try {
       $response = $sendgrid->send($email);
     }
@@ -87,7 +87,7 @@ class SendGridTest_Web extends \PHPUnit_Framework_TestCase {
       ->setSubject('foobar subject')
       ->setText('foobar text')
       ->addTo('p1@mailinator.com')
-      ->addAttachment('./tests/text');
+      ->addAttachment('text');
     try {
       $response = $sendgrid->send($email);
     }


### PR DESCRIPTION
Tests were failing. This adjusts the paths for files so that tests pass. Also adjusted call to Sendgrid/Client to use the alias from L6 in ClientTest.php.