### PR TITLE
Loosen restriction on guzzle to allow for 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "require": {
     "php": ">=7.2",
-    "guzzlehttp/guzzle": "^6.3",
+    "guzzlehttp/guzzle": "^6.3|^7.0",
     "ext-json": "*",
     "ext-mbstring": "*",
     "starkbank/ecdsa": "^0.0.4"


### PR DESCRIPTION
When working on d10 readiness, we ran into some packages, including the sendgrid drupal module failing due to Guzzle 7.x being required in php 8.1 and D10.