### PR TITLE
Add return types for PHP 8.1 compatibility.

### DIFF
--- a/src/Mail/Asm.php
+++ b/src/Mail/Asm.php
@@ -129,7 +129,7 @@ class Asm implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'group_id' => $this->getGroupId(),

--- a/src/Mail/Attachment.php
+++ b/src/Mail/Attachment.php
@@ -208,7 +208,7 @@ class Attachment implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'content' => $this->getContent(),

--- a/src/Mail/BatchId.php
+++ b/src/Mail/BatchId.php
@@ -61,7 +61,7 @@ class BatchId implements JsonSerializable {
    *
    * @return null|string
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return $this->getBatchId();
   }
 }

--- a/src/Mail/BccSettings.php
+++ b/src/Mail/BccSettings.php
@@ -93,7 +93,7 @@ class BccSettings implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/BypassListManagement.php
+++ b/src/Mail/BypassListManagement.php
@@ -66,7 +66,7 @@ class BypassListManagement implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/Category.php
+++ b/src/Mail/Category.php
@@ -63,7 +63,7 @@ class Category implements JsonSerializable {
    *
    * @return string
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return $this->getCategory();
   }
 }

--- a/src/Mail/ClickTracking.php
+++ b/src/Mail/ClickTracking.php
@@ -92,7 +92,7 @@ class ClickTracking implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed  {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/Content.php
+++ b/src/Mail/Content.php
@@ -102,7 +102,7 @@ class Content implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'type' => $this->getType(),

--- a/src/Mail/CustomArg.php
+++ b/src/Mail/CustomArg.php
@@ -96,7 +96,7 @@ class CustomArg implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'key' => $this->getKey(),

--- a/src/Mail/EmailAddress.php
+++ b/src/Mail/EmailAddress.php
@@ -199,7 +199,7 @@ class EmailAddress implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'name' => $this->getName(),

--- a/src/Mail/Footer.php
+++ b/src/Mail/Footer.php
@@ -117,7 +117,7 @@ class Footer implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/Ganalytics.php
+++ b/src/Mail/Ganalytics.php
@@ -218,7 +218,7 @@ class Ganalytics implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/GroupId.php
+++ b/src/Mail/GroupId.php
@@ -60,7 +60,7 @@ class GroupId implements JsonSerializable {
    *
    * @return int
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return $this->getGroupId();
   }
 }

--- a/src/Mail/GroupsToDisplay.php
+++ b/src/Mail/GroupsToDisplay.php
@@ -94,7 +94,7 @@ class GroupsToDisplay implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return $this->getGroupsToDisplay();
   }
 }

--- a/src/Mail/Header.php
+++ b/src/Mail/Header.php
@@ -92,7 +92,7 @@ class Header implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'key' => $this->getKey(),

--- a/src/Mail/IpPoolName.php
+++ b/src/Mail/IpPoolName.php
@@ -66,7 +66,7 @@ class IpPoolName implements JsonSerializable {
    *
    * @return string
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return $this->getIpPoolName();
   }
 }

--- a/src/Mail/Mail.php
+++ b/src/Mail/Mail.php
@@ -1824,7 +1824,7 @@ class Mail implements JsonSerializable {
    * @return null|array
    * @throws SendgridException
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     // Detect if we are using the new dynamic templates
     if ($this->getTemplateId() !== NULL && strpos($this->getTemplateId()
         ->getTemplateId(), 'd-') === 0) {

--- a/src/Mail/MailSettings.php
+++ b/src/Mail/MailSettings.php
@@ -249,7 +249,7 @@ class MailSettings implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'bcc' => $this->getBccSettings(),

--- a/src/Mail/OpenTracking.php
+++ b/src/Mail/OpenTracking.php
@@ -102,7 +102,7 @@ class OpenTracking implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/Personalization.php
+++ b/src/Mail/Personalization.php
@@ -271,7 +271,7 @@ class Personalization implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     if ($this->getHasDynamicTemplate()) {
       $dynamic_substitutions = $this->getSubstitutions();
       $substitutions = NULL;

--- a/src/Mail/SandBoxMode.php
+++ b/src/Mail/SandBoxMode.php
@@ -63,7 +63,7 @@ class SandBoxMode implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/Section.php
+++ b/src/Mail/Section.php
@@ -91,7 +91,7 @@ class Section implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'key' => $this->getKey(),

--- a/src/Mail/SendAt.php
+++ b/src/Mail/SendAt.php
@@ -88,7 +88,7 @@ class SendAt implements JsonSerializable {
    *
    * @return int
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return $this->getSendAt();
   }
 }

--- a/src/Mail/SpamCheck.php
+++ b/src/Mail/SpamCheck.php
@@ -136,7 +136,7 @@ class SpamCheck implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/Subject.php
+++ b/src/Mail/Subject.php
@@ -59,7 +59,7 @@ class Subject implements JsonSerializable {
    *
    * @return string
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return $this->getSubject();
   }
 }

--- a/src/Mail/SubscriptionTracking.php
+++ b/src/Mail/SubscriptionTracking.php
@@ -194,7 +194,7 @@ class SubscriptionTracking implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'enable' => $this->getEnable(),

--- a/src/Mail/Substitution.php
+++ b/src/Mail/Substitution.php
@@ -109,7 +109,7 @@ class Substitution implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'key' => $this->getKey(),

--- a/src/Mail/TemplateId.php
+++ b/src/Mail/TemplateId.php
@@ -75,7 +75,7 @@ class TemplateId implements JsonSerializable {
    *
    * @return string
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return $this->getTemplateId();
   }
 }

--- a/src/Mail/TrackingSettings.php
+++ b/src/Mail/TrackingSettings.php
@@ -230,7 +230,7 @@ class TrackingSettings implements JsonSerializable {
    *
    * @return null|array
    */
-  public function jsonSerialize() {
+  public function jsonSerialize() :mixed {
     return array_filter(
       [
         'click_tracking' => $this->getClickTracking(),


### PR DESCRIPTION
These return types avoid deprecated warnings when using PHP 8.1.