### PR TITLE
Add #[\ReturnTypeWillChange] to suppress PHP 8 deprecation notices

### DIFF
--- a/src/Mail/Asm.php
+++ b/src/Mail/Asm.php
@@ -129,6 +129,7 @@ class Asm implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Attachment.php
+++ b/src/Mail/Attachment.php
@@ -208,6 +208,7 @@ class Attachment implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/BatchId.php
+++ b/src/Mail/BatchId.php
@@ -61,6 +61,7 @@ class BatchId implements JsonSerializable {
    *
    * @return null|string
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getBatchId();
   }

--- a/src/Mail/BccSettings.php
+++ b/src/Mail/BccSettings.php
@@ -93,6 +93,7 @@ class BccSettings implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/BypassListManagement.php
+++ b/src/Mail/BypassListManagement.php
@@ -66,6 +66,7 @@ class BypassListManagement implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Category.php
+++ b/src/Mail/Category.php
@@ -63,6 +63,7 @@ class Category implements JsonSerializable {
    *
    * @return string
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getCategory();
   }

--- a/src/Mail/ClickTracking.php
+++ b/src/Mail/ClickTracking.php
@@ -92,6 +92,7 @@ class ClickTracking implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Content.php
+++ b/src/Mail/Content.php
@@ -102,6 +102,7 @@ class Content implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/CustomArg.php
+++ b/src/Mail/CustomArg.php
@@ -96,6 +96,7 @@ class CustomArg implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/EmailAddress.php
+++ b/src/Mail/EmailAddress.php
@@ -199,6 +199,7 @@ class EmailAddress implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Footer.php
+++ b/src/Mail/Footer.php
@@ -117,6 +117,7 @@ class Footer implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Ganalytics.php
+++ b/src/Mail/Ganalytics.php
@@ -218,6 +218,7 @@ class Ganalytics implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/GroupId.php
+++ b/src/Mail/GroupId.php
@@ -60,6 +60,7 @@ class GroupId implements JsonSerializable {
    *
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getGroupId();
   }

--- a/src/Mail/GroupsToDisplay.php
+++ b/src/Mail/GroupsToDisplay.php
@@ -94,6 +94,7 @@ class GroupsToDisplay implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getGroupsToDisplay();
   }

--- a/src/Mail/Header.php
+++ b/src/Mail/Header.php
@@ -92,6 +92,7 @@ class Header implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/IpPoolName.php
+++ b/src/Mail/IpPoolName.php
@@ -66,6 +66,7 @@ class IpPoolName implements JsonSerializable {
    *
    * @return string
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getIpPoolName();
   }

--- a/src/Mail/Mail.php
+++ b/src/Mail/Mail.php
@@ -1824,6 +1824,7 @@ class Mail implements JsonSerializable {
    * @return null|array
    * @throws SendgridException
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     // Detect if we are using the new dynamic templates
     if ($this->getTemplateId() !== NULL && strpos($this->getTemplateId()

--- a/src/Mail/MailSettings.php
+++ b/src/Mail/MailSettings.php
@@ -249,6 +249,7 @@ class MailSettings implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/OpenTracking.php
+++ b/src/Mail/OpenTracking.php
@@ -102,6 +102,7 @@ class OpenTracking implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Personalization.php
+++ b/src/Mail/Personalization.php
@@ -271,6 +271,7 @@ class Personalization implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     if ($this->getHasDynamicTemplate()) {
       $dynamic_substitutions = $this->getSubstitutions();

--- a/src/Mail/SandBoxMode.php
+++ b/src/Mail/SandBoxMode.php
@@ -63,6 +63,7 @@ class SandBoxMode implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Section.php
+++ b/src/Mail/Section.php
@@ -91,6 +91,7 @@ class Section implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/SendAt.php
+++ b/src/Mail/SendAt.php
@@ -88,6 +88,7 @@ class SendAt implements JsonSerializable {
    *
    * @return int
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getSendAt();
   }

--- a/src/Mail/SpamCheck.php
+++ b/src/Mail/SpamCheck.php
@@ -136,6 +136,7 @@ class SpamCheck implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Subject.php
+++ b/src/Mail/Subject.php
@@ -59,6 +59,7 @@ class Subject implements JsonSerializable {
    *
    * @return string
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getSubject();
   }

--- a/src/Mail/SubscriptionTracking.php
+++ b/src/Mail/SubscriptionTracking.php
@@ -194,6 +194,7 @@ class SubscriptionTracking implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/Substitution.php
+++ b/src/Mail/Substitution.php
@@ -109,6 +109,7 @@ class Substitution implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [

--- a/src/Mail/TemplateId.php
+++ b/src/Mail/TemplateId.php
@@ -75,6 +75,7 @@ class TemplateId implements JsonSerializable {
    *
    * @return string
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return $this->getTemplateId();
   }

--- a/src/Mail/TrackingSettings.php
+++ b/src/Mail/TrackingSettings.php
@@ -230,6 +230,7 @@ class TrackingSettings implements JsonSerializable {
    *
    * @return null|array
    */
+  #[\ReturnTypeWillChange]
   public function jsonSerialize() {
     return array_filter(
       [


### PR DESCRIPTION
As an alternative to https://github.com/taz77/sendgrid-php-ng/pull/42, this PR only adds comments as far as PHP 7 is concerned. However, it will suppress the PHP 8 deprecation notices until you have time to test the more long-term solution offered #42 with PHP 7.